### PR TITLE
format-patch: fix printing "None" at the end

### DIFF
--- a/git_pile/git_pile.py
+++ b/git_pile/git_pile.py
@@ -666,7 +666,7 @@ range-diff:
 def gen_full_tree_patch(output, n_patches, oldbaseline, newbaseline, oldref, newref, prefix, add_header):
     # possibly too big diff, just avoid it for now
     if oldbaseline != newbaseline:
-        return
+        return None
 
     user = git("config --get user.name").stdout.strip()
     email = git("config --get user.email").stdout.strip()
@@ -1097,7 +1097,8 @@ def cmd_format_patch(args):
             tail = gen_full_tree_patch(output, "%04d" % (total_patches + 1),
                                        oldbaseline, newbaseline, oldref, newref,
                                        prefix, config.format_add_header)
-            print(tail)
+            if tail:
+                print(tail)
 
     return 0
 


### PR DESCRIPTION
When the old and new baselines do not match, we don't generate an
"overall diff" since that can be potentially way too big. In that case,
don't print an annoying "None" at the end.

Signed-off-by: Lucas De Marchi <lucas.demarchi@intel.com>