### PR TITLE
am: fix integration with genbranch

### DIFF
--- a/git_pile/git_pile.py
+++ b/git_pile/git_pile.py
@@ -884,6 +884,7 @@ Good luck! ¯\_(ツ)_/¯"""  % (config.dir, config.pile_branch))
         args.branch = None
         args.quiet = False
         args.inplace = False
+        args.dirty = False
         return cmd_genbranch(args)
 
     return 0


### PR DESCRIPTION
Addition of arguments to genbranch needs to be carried for am, for when
it's called with the -g argument.

Signed-off-by: Lucas De Marchi <lucas.demarchi@intel.com>