### PR TITLE
setup: don't warn on directories and hidden files

### DIFF
--- a/git_pile/git_pile.py
+++ b/git_pile/git_pile.py
@@ -218,7 +218,7 @@ def assert_valid_pile_branch(pile):
             has_config = True
         elif l == "series":
             has_series = True
-        elif not l.endswith(".patch"):
+        elif not l.endswith(".patch") and not l.startswith('.') and op.dirname(l) != '':
             non_patches = True
 
     errorstr = "Branch '{pile}' does not look like a pile branch. No '{filename}' file found."


### PR DESCRIPTION
Allow any directory in the pile branch without giving a warning. It may
be useful to allow project-specific configuration there.

Also allow any file or directory starting with '.', which is useful when
integrating with CI or other tools that add configuration on hidden
files.

Signed-off-by: Lucas De Marchi <lucas.demarchi@intel.com>