### PR TITLE
genbranch: Show patch numbers during genbranch

### DIFF
--- a/git_pile/git_pile.py
+++ b/git_pile/git_pile.py
@@ -1143,9 +1143,13 @@ def cmd_genbranch(args):
         else:
             git("checkout -B %s %s" % (args.branch, baseline))
 
-        ret = git_can_fail(apply_cmd + patchlist, stdout=stdout)
-        if ret.returncode != 0:
-            fatal("""Conflict encountered while applying pile patches.
+        n = 1
+        for p in patchlist:
+            print(f'[{n}/{len(patchlist)}]', end=' ', flush=True)
+            ret = git_can_fail(apply_cmd + [p], stdout=stdout)
+            n += 1
+            if ret.returncode != 0:
+                fatal("""Conflict encountered while applying pile patches.
 
 Please resolve the conflict, then run "git am --continue" to continue applying
 pile patches.""")
@@ -1155,7 +1159,11 @@ pile patches.""")
     # work in a separate directory to avoid cluttering whatever the user is doing
     # on the main one
     with temporary_worktree(baseline, root) as d:
-        git(["-C", d] + apply_cmd + patchlist, stdout=stdout)
+        n = 1
+        for p in patchlist:
+            print(f'[{n}/{len(patchlist)}]', end=' ', flush=True)
+            git(["-C", d] + apply_cmd + [p], stdout=stdout)
+            n += 1
 
         if args.dirty:
             raise temporary_worktree.Break


### PR DESCRIPTION
To indicate how long people have to wait for genbranch to complete, turn on
the jazz and print patch numbers during genbranch. Genbranch will show an
output such as the following for each patch which is applied:

[<n>/<total>] Applying: <Patch title>

Signed-off-by: Ashutosh Dixit <ashutosh.dixit@intel.com>