### PR TITLE
Dot not try to split mbox

### DIFF
--- a/git_pile/git_pile.py
+++ b/git_pile/git_pile.py
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: LGPL-2.1+
 
 import argparse
+import email
 import email.header
-import mailbox
 import math
 import os
 import os.path as op
@@ -767,12 +767,11 @@ class PileCover:
 
         f.seek(0)
 
-        mbox = mailbox.mbox(f.name, create=False)
-        if mbox is None or len(mbox) == 0:
+        m = email.message_from_binary_file(f)
+        if not m:
             error("No patches in '%s'" % fname if fname else "stdin")
             return None
 
-        m = mbox[0]
         body_list = m.get_payload(decode=True).decode().splitlines()
         for l in reversed(body_list):
             if not l:
@@ -818,7 +817,7 @@ class PileCover:
         return PileCover(m, version, baseline, pile_commit)
 
     def dump(self, f):
-        from_str = self.m.get_from() or "0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001"
+        from_str = self.m.get_unixfrom() or "0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001"
         f.write("From %s\n" % from_str)
 
         for k, v in zip(self.m.keys(), self.m.values()):


### PR DESCRIPTION
Just open it as a single message. Earlier we needed to support splitting
an mbox because the only interface Patchwork would give us was to
download the patch series with cover. Now patchwork has support to
download only the cover, so we don't have to try to split the mbox
anymore.

This fixes an issue with mailbox.mbox() erroneously splitting the mbox
in the first occurrence of "^From" in the body of the message.

Fix: #19

Signed-off-by: Lucas De Marchi <lucas.demarchi@intel.com>