### PR TITLE
Allow genbranch to generate the same commits over multiple invocations

### DIFF
--- a/git_pile/git_pile.py
+++ b/git_pile/git_pile.py
@@ -61,6 +61,7 @@ class Config:
         self.result_branch = ""
         self.pile_branch = ""
         self.format_add_header = ""
+        self.genbranch_committer_date_is_author_date = True
 
         s = git(["config", "--get-regexp", "^pile\\.*"], check=False, stderr=nul_f).stdout.strip()
         if not s:
@@ -1138,6 +1139,8 @@ def cmd_genbranch(args):
     stdout = nul_f if args.quiet else sys.stdout
     if not args.dirty:
         apply_cmd = ["am", "--no-3way"]
+        if config.genbranch_committer_date_is_author_date:
+            apply_cmd.append("--committer-date-is-author-date")
     else:
         apply_cmd = ["apply", "--unsafe-paths", "-p1"]
 

--- a/git_pile/git_pile.py
+++ b/git_pile/git_pile.py
@@ -69,7 +69,7 @@ class Config:
         for kv in s.split('\n'):
             key, value = kv.strip().split(maxsplit=1)
             # pile.*
-            key = key[5:].replace('-', '_')
+            key = key[5:].translate(str.maketrans('-.', '__'))
             setattr(self, key, value)
 
     def is_valid(self):

--- a/git_pile/git_pile.py
+++ b/git_pile/git_pile.py
@@ -67,13 +67,24 @@ class Config:
             return
 
         for kv in s.split('\n'):
-            key, value = kv.strip().split(maxsplit=1)
+            try:
+                key, value = kv.strip().split(maxsplit=1, sep=" ")
+            except ValueError:
+                key = kv
+                value = None
+
             # pile.*
             key = key[5:].translate(str.maketrans('-.', '__'))
             try:
+                if hasattr(self, key) and isinstance(getattr(self, key), bool):
+                    value = self._value_to_bool(value)
+
                 setattr(self, key, value)
             except e:
                 warn(f"could not set {key}={value} from git config")
+
+    def _value_to_bool(self, value):
+        return value is None or value.lower() in [ "yes", "on", "true", "1" ]
 
     def is_valid(self):
         return self.dir != '' and self.result_branch != '' and self.pile_branch != ''

--- a/git_pile/git_pile.py
+++ b/git_pile/git_pile.py
@@ -70,7 +70,10 @@ class Config:
             key, value = kv.strip().split(maxsplit=1)
             # pile.*
             key = key[5:].translate(str.maketrans('-.', '__'))
-            setattr(self, key, value)
+            try:
+                setattr(self, key, value)
+            except e:
+                warn(f"could not set {key}={value} from git config")
 
     def is_valid(self):
         return self.dir != '' and self.result_branch != '' and self.pile_branch != ''


### PR DESCRIPTION
This changes the arguments to `git am` so the commits generated by applying the patches have the same SHAs if the baseline is the same and the patches are the same.

If the baseline is the same between 2 invocations of `git pile genbranch` the other 2 variables that are accounted for during the hash calculation are: the committer date, committer name and commiter's email. Now we can set these to fixed values: name and email we read from config; date we consider the same as author's.

This allows the generated branch to have the same git objects after multiple invocations, even if done by different developers.