### PR TITLE
Set version as development

### DIFF
--- a/git_pile/__init__.py
+++ b/git_pile/__init__.py
@@ -1,2 +1,2 @@
 # round to the next integer when releasing
-__version__ = '0.96'
+__version__ = '0.96+'


### PR DESCRIPTION
This allows to identify we are using a development version, without much more information. I thought about adding the output of `git describe --tags`, but there is more trouble than it's worth... we'd need to do different things depending if we are executing from git repo or not. So: just add a "+" to indicate it's e.g. 0.96+.

This is quite handy with `pip3 install --user -e ~/p/git-pile` as we can have a "installed version" that is simply executing from the git repository.