### PR TITLE
Teach format-patch to only add new patches

### DIFF
--- a/git_pile/git_pile.py
+++ b/git_pile/git_pile.py
@@ -1064,9 +1064,8 @@ option to this command.""")
         except subprocess.CalledProcessError:
             prefix = "PATCH"
 
-    ca_commits = c_commits + a_commits
-    ca_commits.sort(key=lambda x: x[2])
-    total_patches = len(ca_commits)
+    a_commits.sort(key=lambda x: x[2])
+    total_patches = len(a_commits)
     zero_fill = int(log10_or_zero(total_patches)) + 1
     cover = gen_cover_letter(diff, output, total_patches, newbaseline,
                              git("rev-parse {ref}".format(ref=config.pile_branch)).stdout.strip(),
@@ -1074,7 +1073,7 @@ option to this command.""")
     print(cover)
 
     with tempfile.TemporaryDirectory() as d:
-        for i, c in enumerate(ca_commits):
+        for i, c in enumerate(a_commits):
             format_cmd = ["format-patch", "--subject-prefix=PATCH", "--zero-commit", "--signature="]
             if config.format_add_header:
                 format_cmd.extend(["--add-header", config.format_add_header])

--- a/git_pile/helpers.py
+++ b/git_pile/helpers.py
@@ -103,3 +103,7 @@ def error(s, *args, **kwargs):
 def warn(s, *args, **kwargs):
     kwargs.setdefault("file", sys.stderr)
     print("warning:", s, *args, **kwargs)
+
+
+def orderedset(it):
+    return dict.fromkeys(it).keys()


### PR DESCRIPTION
As detailed in #25, this switches the login in git-pile so when sending a patch series, only patches considered as "added" are actually sent. Review for modified patches are better handled in the cover letter with the interdiff or in the separate "REVIEW" patch.

In order to ease the cover letter review this also reorders the files we show up there.