### PR TITLE
Allow --local instead of --allow-local-pile-commits

### DIFF
--- a/git_pile/git_pile.py
+++ b/git_pile/git_pile.py
@@ -997,7 +997,7 @@ def cmd_format_patch(args):
     if not args.allow_local_pile_commits and not git_ref_is_ancestor(f"{config.pile_branch}", f"{config.pile_branch}@{{u}}"):
         fatal(f"""'{config.pile_branch}' branch contains local commits that aren't visible outside this repo.
 
-If this is indeed the desired behavior, pass --allow-local-pile-commits as
+If this is indeed the desired behavior, pass --allow-local-pile-commits or --local as
 option to this command.""")
 
     # possibly too big diff, just avoid it for now - force it to false
@@ -1517,7 +1517,7 @@ series  config  X'.patch  Y'.patch  Z'.patch
         action="store_true",
         default=False)
     parser_format_patch.add_argument(
-        "--allow-local-pile-commits",
+        "--allow-local-pile-commits", "--local",
         help="Bypass check for local pile commits to allow partial patch series",
         action="store_true",
         default=False)


### PR DESCRIPTION
--allow-local-pile-commits was made long because initially there was no
real use case for it. However it turns out this is useful when iterating
a new version of the patch and you have to fix conflicts while running
`git genbranch -i` command so you can easily get pile and result-branch
back in sync.

Signed-off-by: Lucas De Marchi <lucas.demarchi@intel.com>