### PR TITLE
format-patch: Set the REVIEW patch content type to text/x-diff

### DIFF
--- a/git_pile/git_pile.py
+++ b/git_pile/git_pile.py
@@ -701,7 +701,7 @@ From: {user} <{email}>
 Date: {date}
 Subject: [{prefix} {n_patches}/{n_patches}] REVIEW: Full tree diff against {oldref}
 MIME-Version: 1.0
-Content-Type: text/plain; charset=UTF-8
+Content-Type: text/x-diff; charset=UTF-8
 Content-Transfer-Encoding: 8bit{add_header}
 
 Auto-generated diff between {oldref}..{newref}


### PR DESCRIPTION
If the end result is empty (just reordering patches etc), the REVIEW
patch will be an empty patch. Patchwork doesn't parse empty patches as
patches if the content-type is text/plain, but using text/x-diff
forces it to grab the whole email as the patch. We don't need to care
what ends up in the patch as far as patchwork is concerned, as no one
needs to feed that patch as such back to git, only the cover letter is
used.

Signed-off-by: Petri Latvala <petri.latvala@intel.com>