### PR TITLE
version: do not use '+' in the version

### DIFF
--- a/git_pile/__init__.py
+++ b/git_pile/__init__.py
@@ -1,2 +1,2 @@
 # round to the next integer when releasing
-__version__ = '0.97+'
+__version__ = '0.98-dev'


### PR DESCRIPTION
pip complains that it doesn't follow PEP 440:
    
            WARNING: Built wheel for git-pile is invalid: Metadata 1.2 mandates PEP
            440 version, but '0.97-' is not
    

Signed-off-by: Lucas De Marchi <lucas.demarchi@intel.com>