### PR TITLE
am: add option to fallback to "fuzzy" apply

### DIFF
--- a/git_pile/git_pile.py
+++ b/git_pile/git_pile.py
@@ -882,6 +882,56 @@ class PileCover:
         f.write(self.m.get_payload(decode=False))
 
 
+def git_am_solve_diff_hunk_conflicts(patchesdir):
+    status = git(f"-C {patchesdir} status --porcelain").stdout.splitlines()
+    resolved = True
+    any_unmerged = False
+
+    # double check we are actually resolving unmerged, we could have failed due
+    # to other reasons
+    for l in status:
+        if l[0] == 'U' or l[1] == 'U':
+            any_unmerged = True
+            break
+
+    if not any_unmerged:
+        return False
+
+    warn("\n\n--------------------------- git-pile")
+    warn("git am failed, trying to fix conflicts automatically")
+
+    sed = run_wrapper('sed', capture=True)
+
+    # solve UU conflicts only, we don't really know how to resolve the others
+    for f in status:
+        if not f.startswith("UU"):
+            resolved = False
+            continue
+
+        f = f.split()[1]
+        path = op.join(patchesdir, f)
+
+        print(f"Trying to fix conflicts in {f}... ", end="", file=sys.stderr)
+        sed(['-i', '-e', '/^<<<<<<< HEAD/ {N;N;N;N; s/<<<<<<< HEAD.*\\n@@.*\\n=======.*\\n\\(@@.*\\)\\n>>>>>>>.*/\\1/g}', path])
+
+        # Check with all markers are gone
+        any_markers = False
+        with open(path) as fp:
+            for l in fp:
+                if l.startswith("<<<<<<< HEAD"):
+                    any_markers = True
+                    break
+
+        if any_markers:
+            resolved = False
+            print("fail: couldn't solve all conflicts, some of them left behind", file=sys.stderr)
+        else:
+            print("done", file=sys.stderr)
+            git(f"-C {patchesdir} add {f}")
+
+    return resolved
+
+
 def cmd_am(args):
     config = Config()
     if not config.check_is_valid():
@@ -904,6 +954,12 @@ def cmd_am(args):
     with subprocess.Popen(["git", "-C", patchesdir, "am", "-3"],
             stdin=subprocess.PIPE, universal_newlines=True) as proc:
         cover.dump(proc.stdin)
+
+    if proc.returncode != 0 and args.fuzzy:
+        if git_am_solve_diff_hunk_conflicts(patchesdir):
+            info("Yay, fixed!")
+            git("am -C {patchesdir} --continue")
+            proc.returncode = 0
 
     if proc.returncode != 0:
         fatal("""git am failed, you will need to continue manually.
@@ -1663,6 +1719,14 @@ shortcut. From more verbose to the easiest ones:
              "the PILE_BRANCH will have diverged.",
         choices=["top", "pile-commit"],
         default="top")
+    parser_am.add_argument(
+        "--fuzzy",
+        help="Allow to apply a patch even with conflicts in the diff hunk line numbers. "
+             "When using this option we will automatically solving the conflicts of this kind "
+             "by taking `theirs` version as the correct. See 'HOW CONFLICTS ARE PRESENTED' in "
+             "GIT-MERGE(1)",
+        action="store_true",
+        default=False)
     parser_am.set_defaults(func=cmd_am)
 
     # baseline

--- a/git_pile/helpers.py
+++ b/git_pile/helpers.py
@@ -120,3 +120,26 @@ def warn(s, *args, **kwargs):
 
 def orderedset(it):
     return dict.fromkeys(it).keys()
+
+
+def prompt_yesno(question, default):
+    if default is None:
+        choices = ' [y/n]: '
+        default_reply = None
+    elif not default:
+        choices = ' [y/N]: '
+        default_reply = 'n'
+    else:
+        choices = ' [Y/n]: '
+        default_reply = 'y'
+
+    reply = None
+    while reply is None:
+        reply = str(input(question + choices)).lower().strip() or default_reply
+
+    if reply[0] == 'y':
+        return True
+    if reply[0] == 'n':
+        return False
+    
+    return default


### PR DESCRIPTION
When a patch doesn't apply, several times it's just because the line
numbers in the diff hunks changed. A lazy resolution is to take either
side and eventually fix things up when doing genbranch. I've been using
this manually and it speeds up a lot when applying patches with
conflicts. Even in the case we can't solve them all, it already helps
as we will likely have those kind of conflicts.

My implementation idea was to do something much simpler:

    return git_can_fail(["-C", patchesdir,
                         "-c", "mergetool.diffhunkkeeptheirs.cmd=\"sed -i -e '/^<<<<<<< HEAD/ {N;N;N;N; s/<<<<<<< HEAD.*\\n@@.*\\n=======.*\\n\\(@@.*\\)\\n>>>>>>>.*/\\1/g}' ${MERGED}\"",
                         "-c", "mergetool.diffhunkkeeptheirs.trustExictCode=true",
                         "-c", "mergetool.keepBackup=false",
                         "mergetool", "-y",  "--tool=diffhunkkeeptheirs"],
                         stdin=sys.stdin, stdout=sys.stdout)

Unfortunately, after multiple tries, I couldn't figure out the correct
escape sequence to the cmd setting. So here I do the implementation
myself by parsing git-status and calling sed on any file that had
conflicts UU (update/update), meaning we have conflict markers in them.

Fix: #4
Signed-off-by: Lucas De Marchi <lucas.demarchi@intel.com>