### PR TITLE
format-patch: allow cover message from file/stdin

### DIFF
--- a/git_pile/git_pile.py
+++ b/git_pile/git_pile.py
@@ -16,7 +16,7 @@ from contextlib import contextmanager
 from time import strftime
 
 from .helpers import error, info, fatal, warn
-from .helpers import run_wrapper, set_debugging, orderedset
+from .helpers import run_wrapper, set_debugging, orderedset, open_or_stdin
 from . import __version__
 
 try:
@@ -652,8 +652,7 @@ def genpatches(output, base_commit, result_commit):
 
 def get_cover_letter_message(commit_with_message, file_with_message):
     if file_with_message:
-        is_stdin = file_with_message == '-'
-        with open(sys.stdin.fileno() if is_stdin else file_with_message, closefd=not is_stdin) as f:
+        with open_or_stdin(file_with_message, "r") as f:
             subject = f.readline().strip()
             body = "".join(f.readlines()).strip()
     elif commit_with_message:

--- a/git_pile/git_pile.py
+++ b/git_pile/git_pile.py
@@ -650,13 +650,18 @@ def genpatches(output, base_commit, result_commit):
     return 0
 
 
-def get_cover_letter_message(commit_with_message):
-    if not commit_with_message:
-        subject = "*** SUBJECT HERE ***"
-        body = "*** BLURB HERE ***"
-    else:
+def get_cover_letter_message(commit_with_message, file_with_message):
+    if file_with_message:
+        is_stdin = file_with_message == '-'
+        with open(sys.stdin.fileno() if is_stdin else file_with_message, closefd=not is_stdin) as f:
+            subject = f.readline().strip()
+            body = "".join(f.readlines()).strip()
+    elif commit_with_message:
         subject = git(["log", "--format=%s", "-1", commit_with_message]).stdout.strip()
         body = git(["log", "--format=%b",  "-1", commit_with_message]).stdout.strip()
+    else:
+        subject = "*** SUBJECT HERE ***"
+        body = "*** BLURB HERE ***"
 
     return subject, body
 
@@ -1060,8 +1065,15 @@ def _parse_range_diff(range_diff_commits):
 
     return c_commits, a_commits, d_commits, diff_filter_list
 
+
+def assert_format_patch_compatible_args(args):
+    if args.commit_with_message and args.file:
+        fatal("-C and -F options are mutually exclusive")
+
+
 def cmd_format_patch(args):
     assert_required_tools()
+    assert_format_patch_compatible_args(args)
 
     config = Config()
     if not config.check_is_valid():
@@ -1131,7 +1143,8 @@ option to this command.""")
         total_patches += 1
 
     zero_fill = int(log10_or_zero(total_patches)) + 1
-    cover_subject, cover_body = get_cover_letter_message(args.commit_with_message)
+
+    cover_subject, cover_body = get_cover_letter_message(args.commit_with_message, args.file)
     cover = gen_cover_letter(diff, output, total_patches, newbaseline,
                              git("rev-parse {ref}".format(ref=config.pile_branch)).stdout.strip(),
                              prefix, range_diff_commits, config.format_add_header,
@@ -1590,6 +1603,10 @@ series  config  X'.patch  Y'.patch  Z'.patch
         help="Take an existing commit object, and reuse the log message as the cover-letter, like documented in GIT-COMMIT(1)",
         dest="commit_with_message",
         metavar="COMMIT")
+    parser_format_patch.add_argument(
+        '-F', '--file',
+        help="Take the commit message from the given file. Use - to read the message from the standard input. Like documented in GIT-COMMIT(1)",
+        metavar="FILE")
     parser_format_patch.add_argument(
         "refs",
         help="""

--- a/git_pile/git_pile.py
+++ b/git_pile/git_pile.py
@@ -1587,6 +1587,7 @@ series  config  X'.patch  Y'.patch  Z'.patch
         default=None)
     parser_format_patch.add_argument(
         "-C", "--reuse-message",
+        help="Take an existing commit object, and reuse the log message as the cover-letter, like documented in GIT-COMMIT(1)",
         dest="commit_with_message",
         metavar="COMMIT")
     parser_format_patch.add_argument(

--- a/git_pile/helpers.py
+++ b/git_pile/helpers.py
@@ -12,6 +12,19 @@ def set_debugging(val):
     global debug_run
     debug_run = val
 
+
+# Like open(), but reserves file == "-", file == "" or file == None for stdin
+def open_or_stdin(file, *args, **kwargs):
+    if not file or file == "-":
+        # we can't simply return sys.stdin as a file object may be used
+        # as a context manager, so f would implicitely be closed and fail
+        # a second call. We never want to implicitely close stdin
+        kwargs["closefd"] = False
+        return open(sys.stdin.fileno(), *args, **kwargs)
+
+    return open(file, *args, **kwargs)
+
+
 class run_wrapper:
     def __init__(self, cmd, env_default=None, capture=False, check=True, print_error_as_ignored=False):
         """


### PR DESCRIPTION
Using this in https://github.com/git-pile/playground/commit/5e2f503aba810853eb051b4e7d38b8f96cb723ee
It's useful for when we already have the commit message somewhere else.