### PR TITLE
genbranch: add -v and --signoff

### DIFF
--- a/git_pile/git_pile.py
+++ b/git_pile/git_pile.py
@@ -1699,7 +1699,6 @@ shortcut. From more verbose to the easiest ones:
             "--debug",
             help="Turn on debugging output",
             action="store_true", default=False)
-        subp.add_argument('-v', '--version', action='version', version='git-pile ' + __version__)
 
     parser.add_argument('-v', '--version', action='version', version='git-pile ' + __version__)
 


### PR DESCRIPTION
Two useful options while generating patches:
1. Allow to add our signoff to the cover
2. Parse the -v / --reroll-count option, just like git-format-patch