### PR TITLE
format-patch: switch last patch to text/x-patch

### DIFF
--- a/git_pile/git_pile.py
+++ b/git_pile/git_pile.py
@@ -751,7 +751,7 @@ From: {user} <{email}>
 Date: {date}
 Subject: [{prefix} {n_patches}/{n_patches}] REVIEW: Full tree diff against {oldref}
 MIME-Version: 1.0
-Content-Type: text/x-diff; charset=UTF-8
+Content-Type: text/x-patch; charset=UTF-8
 Content-Transfer-Encoding: 8bit{add_header}
 
 Auto-generated diff between {oldref}..{newref}


### PR DESCRIPTION
We can't use text/plain since patchwork would otherwise wait
indefinitely for the last patch. However looking at b4, it uses
text/plain and text/x-patch. Try to switch to x-patch instead of using
x-diff for improved compatibility.

Signed-off-by: Lucas De Marchi <lucas.demarchi@intel.com>