### PR TITLE
reset: add --pile-only

### DIFF
--- a/git_pile/__init__.py
+++ b/git_pile/__init__.py
@@ -1,2 +1,2 @@
 # round to the next integer when releasing
-__version__ = '0.98'
+__version__ = '0.99-dev'


### PR DESCRIPTION
Allow to reset just the pile instead of synchronizing both branches.
This is a shortcut to:

        cd patches
        git rev-parse HEAD
        git reset --hard pile@{u}

The commands above, or variants thereof, are common when we are going to
generate a v2 of a patch series and for that we apply the previous
version from somewhere. Commands for a v2 are more or less like:

        git pile am /tmp/v1.mbx
        git pile genbranch -i
        r=$(git -C patches rev-parse HEAD)
        git -c patches reset --hard HEAD^
        git pile format-patch -v2 -C $r

This now can be done with:

        git pile am /tmp/v1.mbx
        git pile genbranch -i
        git pile reset -p
        git pile format-patch -v2 -C <paste>

In which paste is simply what we gave in the output of `reset -p`.

Signed-off-by: Lucas De Marchi <lucas.demarchi@intel.com>
