### PR TITLE
Override whitespace config

### DIFF
--- a/git_pile/git_pile.py
+++ b/git_pile/git_pile.py
@@ -988,7 +988,7 @@ def cmd_am(args):
             print("Could not checkout commit %s\n as baseline - you probably need to git-fetch it." % cover.pile_commit,
                   file=sys.stderr)
 
-    with subprocess.Popen(["git", "-C", patchesdir, "am", "-3"],
+    with subprocess.Popen(["git", "-C", patchesdir, "am", "-3", "--whitespace=nowarn"],
             stdin=subprocess.PIPE, universal_newlines=True) as proc:
         cover.dump(proc.stdin)
 
@@ -1321,7 +1321,7 @@ def _genbranch(root, patchesdir, config, args):
     stderr = sys.stderr
 
     if not args.dirty:
-        apply_cmd = ["-c", "core.splitIndex=true", "am", "--no-3way"]
+        apply_cmd = ["-c", "core.splitIndex=true", "am", "--no-3way", "--whitespace=warn"]
         if config.genbranch_committer_date_is_author_date:
             apply_cmd.append("--committer-date-is-author-date")
         if args.fix_whitespace:


### PR DESCRIPTION
Besides the warnings we see when applying the interdiff, if the user has
configured apply.whitespace=strip, the final patch saved in the pile
will be corrupted. This causes a subsequent genbranch to fail due to
malformed patch. Critical here is to override the config during
git-pile-am phase, but to make sure the result branch is the same
regardless of configuration, let's override it in genbranch too.

Signed-off-by: Lucas De Marchi <lucas.demarchi@intel.com>