### PR TITLE
am: Fix checking pending am in the wrong worktree

### DIFF
--- a/git_pile/git_pile.py
+++ b/git_pile/git_pile.py
@@ -979,9 +979,9 @@ def cmd_am(args):
         return 1
 
     info("Entering '%s' directory" % config.dir)
-    gitdir = git_worktree_get_git_dir()
+    gitdir = git_worktree_get_git_dir(patchesdir)
     if op.isdir(op.join(gitdir, "rebase-apply")):
-        fatal("Already on an am or rebase operation", file=sys.stderr)
+        fatal(f"Already on am or rebase operation in worktree {patchesdir}", file=sys.stderr)
 
     if args.strategy == "pile-commit":
         if git(["-C", patchesdir, "reset", "--hard", cover.pile_commit], check=False).returncode != 0:


### PR DESCRIPTION
        $ git am bla.patch
        ... conflicts
        $ git pile am cover.patch
        fatal: Already on an am or rebase operation

That's because we are checking the wrong worktree. We have to check if
the worktree where pile is checkout is in the middle of am, not whatever
worktree we are on currently. This now becomes:

        $ git pile am .git/p/v2-0000-cover-letter.patch
        ‣ Entering 'patches' directory
        fatal: Already on am or rebase operation in worktree /home/lucas/p/linux/patches

Signed-off-by: Lucas De Marchi <lucas.demarchi@intel.com>