### PR TITLE
Make Bash completions configurable from env vars

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,9 @@ else:
     mandir = '/usr/share/man'
     bash_completion_dir = '/etc/bash_completion.d'
 
+if 'BASH_COMPLETION_DIR' in os.environ:
+    bash_completion_dir = os.environ['BASH_COMPLETION_DIR']
+
 setup(
     name="git-pile",
     zip_safe = False,


### PR DESCRIPTION
This makes packaging easier on distros where the default location for Bash completions is somewhre else (for example in /usr/share/bash-completion/completions).