### PR TITLE
am: No backtrace if file doesn't exist

### DIFF
--- a/git_pile/git_pile.py
+++ b/git_pile/git_pile.py
@@ -890,7 +890,10 @@ class PileCover:
         if fname is None:
             oldf = sys.stdin.buffer
         else:
-            oldf = open(fname, 'rb')
+            try:
+                oldf = open(fname, 'rb')
+            except FileNotFoundError as e:
+                fatal(e)
 
         # look-ahead on first line and fix up if needed
         l0 = oldf.readline()


### PR DESCRIPTION
	$ git pile am /tmp/ambox
	fatal: [Errno 2] No such file or directory: '/tmp/ambox'

This is less scary than

	$ git pile am -s pile-commit /tmp/.ambox
	Traceback (most recent call last):
	  File "/home/lucas/.local/bin/git-pile", line 7, in <module>
	    exec(compile(f.read(), __file__, 'exec'))
	  File "/home/lucas/p/git-pile/git-pile", line 12, in <module>
	    sys.exit(git_pile.main(*sys.argv[1:]))
	  File "/home/lucas/p/git-pile/git_pile/git_pile.py", line 2190, in main
	    return args.func(args)
	  File "/home/lucas/p/git-pile/git_pile/git_pile.py", line 1054, in cmd_am
	    cover = PileCover.parse(args.mbox_cover)
	  File "/home/lucas/p/git-pile/git_pile/git_pile.py", line 885, in parse
	    oldf = open(fname, 'rb')
	FileNotFoundError: [Errno 2] No such file or directory: '/tmp/.ambox'

Signed-off-by: Lucas De Marchi <lucas.demarchi@intel.com>