### PR TITLE
test: Add support for using coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,7 @@ pip-log.txt
 cscope.*
 ncscope.*
 
+# coverage data file
+.coverage
+
 /git-pile-wrapper-*

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ Manage a pile of patches on top of a git branch
  - Python >= 3.6
  - git >= 2.19
  - Python modules:
-   - argcomplete (optional)
+   - argcomplete (optional for shell completion)
+   - coverage (optional for tests)
 
 ## Quickstart
 

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,9 @@ setup(
         ]
     },
     python_requires=">=3.6",
+    extras_require={
+        "tests": ["coverage~=6.5"],
+    },
     data_files=[
         (bash_completion_dir, ["extra/git-pile-complete.sh"]),
         (

--- a/test/common.bash
+++ b/test/common.bash
@@ -27,3 +27,7 @@ create_simple_repo() {
   git add c; git commit -m "Add c"
   popd
 }
+
+if [[ -n $COVERAGE ]]; then
+    export PATH="$BATS_TEST_DIRNAME/coverage-shim:$PATH"
+fi

--- a/test/coverage-shim/git-pile
+++ b/test/coverage-shim/git-pile
@@ -1,0 +1,8 @@
+#!/bin/bash
+IFS_BKP="$IFS"
+IFS=$'\n'
+git_pile_paths=($(type -a git-pile))
+IFS="$IFS_BKP"
+git_pile_script="${git_pile_paths[1]#git-pile is }"
+export COVERAGE_FILE="$(realpath $(dirname ${BASH_SOURCE[0]})/../../.coverage)"
+exec coverage run -a "$git_pile_script" "$@"


### PR DESCRIPTION
Implement this in non-intrusive way by defining a shim script that wraps calls to git-pile with `coverage run`. Coverage data can be collected with:

  COVERAGE=1 bats test

Then the command `coverage` can be used to generate reports.

NOTE: Another way to implement this would be changing the git-pile script to use coverage API[1] directly. That would result in adding code that would not be used by the end-user and would require some workarounds, like encapsulating the main logic (including the `import git_pile.git_pile as git_pile` statement) into a function, which would have to be called after we tell coverage to start recording data. Because of that, prefer to use the shim-based approach.

[1] https://coverage.readthedocs.io/en/6.5.0/api.html#api