### PR TITLE
pile: Make call to ls-tree backward-compatible

### DIFF
--- a/git_pile/pile.py
+++ b/git_pile/pile.py
@@ -315,7 +315,6 @@ class _RevReader(_FileReader):
             "ls-tree",
             "-z",
             "--full-tree",
-            "--format=%(objectname) %(objecttype) %(path)",
             self.__rev,
         ]
         if path is not None:
@@ -324,7 +323,7 @@ class _RevReader(_FileReader):
 
         info = collections.OrderedDict()
         for entry in _git(cmd).stdout.rstrip("\x00").split("\x00"):
-            sha1, objecttype, name = entry.split(" ", maxsplit=2)
+            _, objecttype, sha1, name = entry.split(maxsplit=3)
             info[name] = name, objecttype, sha1
 
         if path is None:


### PR DESCRIPTION
The `--format` option for `git ls-tree` is available as of version 2.36. As we support git>=2.19, do not use that option in the command.

Fixes: 9a8118439e68 ("pile: Add method Pile.baseline()")
Fixes: 359ca73e4e08 ("pile: Add method Pile.validate_structure()")