### PR TITLE
test: Allow using alternate git binary

### DIFF
--- a/test/common.bash
+++ b/test/common.bash
@@ -31,3 +31,13 @@ create_simple_repo() {
 if [[ -n $COVERAGE ]]; then
     export PATH="$BATS_TEST_DIRNAME/coverage-shim:$PATH"
 fi
+
+if [[ -n "$GIT" ]]; then
+    if [[ -d "$GIT" || ! -x "$GIT" ]]; then
+        echo "Path passed to GIT must be an executable file: $GIT" >&2
+        exit 1
+    fi
+    mkdir "$BATS_FILE_TMPDIR/git-path"
+    ln -s "$GIT" "$BATS_FILE_TMPDIR/git-path/git"
+    export PATH="$BATS_FILE_TMPDIR/git-path:$PATH"
+fi


### PR DESCRIPTION
Allow user to use `GIT=<path-to-git-binary> bats ...` to run tests with a different version of git.

While we are discussing ways of implementing CI with different git versions (#92), this patch can is still useful for folks wishing to manually define an alternative git binary to run tests with.