### PR TITLE
am: Fix call to cmd_genbranch()

### DIFF
--- a/git_pile/git_pile.py
+++ b/git_pile/git_pile.py
@@ -1133,7 +1133,7 @@ Good luck! ¯\_(ツ)_/¯"""
     if args.genbranch:
         info(f"Generating branch '{config.result_branch}'")
         genbranch_args = parse_args(["genbranch", "--force"])
-        return cmd_genbranch(genbranch_args)
+        return cmd_genbranch(genbranch_args, config)
 
     return 0
 


### PR DESCRIPTION
This call got overlooked when doing the refactor to pass the config object to command functions.

Fixes: 38ad271f5700 ("git-pile: Reuse config object in subcommands")