### PR TITLE
genlinear-branch: Fix missing pile_range

### DIFF
--- a/git_pile/git_pile.py
+++ b/git_pile/git_pile.py
@@ -2024,6 +2024,8 @@ class GenbranchCmd(PileCommand):
 def get_refs_from_linearized(incremental, pile_branch, start_ref, linear_branch, notes_ref):
     if start_ref:
         pile_range = f"{start_ref}^..{pile_branch}"
+    else:
+        pile_range = pile_branch
 
     if not incremental:
         return None, pile_range

--- a/test/40_genlinear_branch.bats
+++ b/test/40_genlinear_branch.bats
@@ -1,0 +1,70 @@
+#!/usr/bin/env bats
+setup_file() {
+  bats_require_minimum_version 1.7.0
+  load 'common'
+
+  create_simple_repo "$BATS_FILE_TMPDIR/testrepo"
+}
+
+add_pile_commits() {
+  local n_commits=$1
+  local fn_number=$2
+
+  for i in $(seq 1 $n_commits); do
+    fn="foo${fn_number}.txt"
+    touch $fn
+    git add $fn
+    git commit -m "Add $fn"
+    git pile genpatches -m "Add patch adding $fn"
+    let fn_number+=1
+  done
+}
+
+setup() {
+  git clone --bare "$BATS_FILE_TMPDIR/testrepo" "$BATS_TEST_TMPDIR/remoterepo"
+
+  git clone "$BATS_TEST_TMPDIR/remoterepo" "$BATS_TEST_TMPDIR/testrepo"
+  pushd "$BATS_TEST_TMPDIR/testrepo"
+  git pile init
+  git config pile.genbranch-user-name = "pile bot"
+  git config pile.genbranch-user-email = "git@pi.le"
+  git checkout -b internal
+
+  add_pile_commits 3 1
+  git push origin -u --all
+}
+
+# Check a bootstrap of genlinear branch works
+@test "genlinear-branch-bootstrap" {
+  git pile genlinear-branch -b internal-linear
+  [ "$(git diff internal..internal-linear)" = "" ]
+  [ "$(git log --format=%s pile)" = "$(git log --format=%s internal-linear)" ]
+
+  trailers="$(git log --format="%N" --notes=refs/notes/internal-linear internal-linear | sed -e 's/pile-commit: //' -e '/^$/d')"
+  [ "$(git log --format=%H pile)" = "$trailers" ]
+
+  # since we built a very simple result-branch with just additions on top,
+  # it's possible to check commit by commit
+  i=0
+  n=$(git rev-list --count internal-linear)
+  let n-=2
+  for i in $(seq 0 $n); do
+    [ "$(git diff internal~$i internal-linear~$i)" = "" ]
+  done
+}
+
+@test "genlinear-branch-incremental" {
+  pile_rev0=$(git rev-parse pile)
+  git pile genlinear-branch -b internal-linear
+  rev0=$(git rev-parse internal-linear)
+
+  # add more 4 commits
+  add_pile_commits 3 4
+
+  # make sure genlinear-branch picks up where it left of
+  git pile genlinear-branch -b internal-linear
+  [ $(git rev-list --count $rev0..internal-linear) = 3 ]
+
+  trailers="$(git log --format="%N" --notes=refs/notes/internal-linear $rev0..internal-linear | sed -e 's/pile-commit: //' -e '/^$/d')"
+  [ "$(git log --format=%H $pile_rev0..pile)" = "$trailers" ]
+}


### PR DESCRIPTION
	[igt-gpu-tools]$ git pile genlinear-branch -b internal-linear
	Traceback (most recent call last):
	  File "/home/adixit/.local/bin/git-pile", line 4, in <module>
	    __import__('pkg_resources').run_script('git-pile==1.0.dev0', 'git-pile')
	  File "/usr/lib/python3.10/site-packages/pkg_resources/__init__.py", line 656, in run_script
	    self.require(requires)[0].run_script(script_name, ns)
	  File "/usr/lib/python3.10/site-packages/pkg_resources/__init__.py", line 1453, in run_script
	    exec(code, namespace, namespace)
	  File "/home/adixit/.local/lib/python3.10/site-packages/git_pile-1.0.dev0-py3.10.egg/EGG-INFO/scripts/git-pile", line 12, in <module>
	    sys.exit(git_pile.main(*sys.argv[1:]))
	  File "/home/adixit/.local/lib/python3.10/site-packages/git_pile-1.0.dev0-py3.10.egg/git_pile/git_pile.py", line 2432, in main
	    return args.func(args, config)
	  File "/home/adixit/.local/lib/python3.10/site-packages/git_pile-1.0.dev0-py3.10.egg/git_pile/git_pile.py", line 1698, in cmd_genlinear_branch
	    parent_ref, pile_range = get_refs_from_linearized(args.incremental, config.pile_branch, args.start_ref, branch, notes_ref)
	  File "/home/adixit/.local/lib/python3.10/site-packages/git_pile-1.0.dev0-py3.10.egg/git_pile/git_pile.py", line 1660, in get_refs_from_linearized
	    return None, pile_range
	UnboundLocalError: local variable 'pile_range' referenced before assignment

When commit 6171f65cfeaf ("genlinear-branch: Allow to override first commit") added an option to override the start commit, it didn't handle well when start_ref is None.

Fix: 6171f65cfeaf ("genlinear-branch: Allow to override first commit")
Fix: #90
Signed-off-by: Lucas De Marchi <lucas.demarchi@intel.com>