### PR TITLE
Add worktree-aware pile

### DIFF
--- a/git_pile/helpers.py
+++ b/git_pile/helpers.py
@@ -82,6 +82,7 @@ class run_wrapper:
         kwargs["check"] = kwargs.get("check", self.check)
         kwargs["shell"] = kwargs.get("shell", self.shell)
 
+        cmd = [self.cmd] if isinstance(self.cmd, str) else self.cmd.copy()
         if isinstance(s, str):
             l = s.split()
         elif not s:
@@ -89,13 +90,13 @@ class run_wrapper:
         else:
             l = s
 
-        l.insert(0, self.cmd)
+        cmd.extend(l)
 
-        cmd_debug = " ".join(shlex.quote(x) for x in l)
+        cmd_debug = " ".join(shlex.quote(x) for x in cmd)
         if debug_run:
             print("+ " + cmd_debug, file=sys.stderr)
 
-        ret = subprocess.run(l, *args, **kwargs)
+        ret = subprocess.run(cmd, *args, **kwargs)
 
         if self.print_error_as_ignored and ret.returncode != 0:
             print("Ignoring failed command: '{}'".format(cmd_debug))

--- a/git_pile/helpers.py
+++ b/git_pile/helpers.py
@@ -82,17 +82,8 @@ class run_wrapper:
         kwargs["check"] = kwargs.get("check", self.check)
         kwargs["shell"] = kwargs.get("shell", self.shell)
 
-        cmd = [self.cmd] if isinstance(self.cmd, str) else self.cmd.copy()
-        if isinstance(s, str):
-            l = s.split()
-        elif not s:
-            l = []
-        else:
-            l = s
+        cmd, cmd_debug = self._assemble_cmd(s)
 
-        cmd.extend(l)
-
-        cmd_debug = " ".join(shlex.quote(x) for x in cmd)
         if debug_run:
             print("+ " + cmd_debug, file=sys.stderr)
 
@@ -103,6 +94,24 @@ class run_wrapper:
             print("\t", ret.stderr, end="", file=sys.stderr)
 
         return ret
+
+    def _assemble_cmd(self, tail):
+        if self.shell:
+            cmd = self.cmd + " " + tail
+            cmd_debug = cmd
+        else:
+            cmd = [self.cmd] if isinstance(self.cmd, str) else self.cmd.copy()
+            if isinstance(tail, str):
+                l = tail.split()
+            elif not tail:
+                l = []
+            else:
+                l = tail
+
+            cmd.extend(l)
+            cmd_debug = " ".join(shlex.quote(x) for x in cmd)
+
+        return cmd, cmd_debug
 
 
 class subcmd:

--- a/test/10_init.bats
+++ b/test/10_init.bats
@@ -25,3 +25,38 @@ setup() {
   # init again passes
   git pile init -p pile -r internal
 }
+
+@test "init-multiple-pile" {
+  pushd "$BATS_TEST_TMPDIR/testrepo"
+
+  # requirement for working with multiple piles
+  git config extensions.worktreeConfig true
+
+  # create the first setup (pile, internal)
+  git pile init -p pile -r internal
+  git checkout -b internal
+  git push -u origin pile internal
+
+  # add another worktree to work on
+  git worktree add --checkout -b internal-next ../testrepo-next
+  cd ../testrepo-next
+
+  # create the second setup (pile-next, internal-next)
+  # and add something on top to compare later that it doesn't
+  # match in the first setup
+  git pile init -p pile-next -r internal-next
+  touch pile-next-file.txt
+  git add pile-next-file.txt
+  git commit -m "Add pile-next-file.txt"
+  git pile genpatches -m "Add patch adding pile-next-file.txt"
+  # make sure git-pile managed the separate config in second setup
+  [ "$(git config pile.pile-branch)" = "pile-next" ]
+
+  cd ../testrepo
+  # make sure git-pile managed the separate config in first setup
+  [ "$(git config pile.pile-branch)" = "pile" ]
+  git pile reset
+  [ "$(git rev-parse internal)" != "$(git rev-parse internal-next)" ]
+  [ "$(git rev-parse pile)" != "$(git rev-parse pile-next)" ]
+  [ ! -f pile-next-file.txt ]
+}

--- a/test/40_genlinear_branch.bats
+++ b/test/40_genlinear_branch.bats
@@ -68,3 +68,22 @@ setup() {
   trailers="$(git log --format="%N" --notes=refs/notes/internal-linear $rev0..internal-linear | sed -e 's/pile-commit: //' -e '/^$/d')"
   [ "$(git log --format=%H $pile_rev0..pile)" = "$trailers" ]
 }
+
+# Check pre/post genbranch hooks
+@test "genlinear-branch-with-hooks" {
+  git pile genlinear-branch -b internal-linear \
+        --pre-genbranch-exec "echo foo >> $PWD/out.txt" \
+	--post-genbranch-exec "echo bar >> $PWD/out.txt"
+  [ -f "out.txt" ]
+
+  # initial commit doesn't get a post exec
+  echo foo >> expected.txt
+
+  n=$(git rev-list --count pile)
+  for (( i=0; i < n - 1; i++ )); do
+    echo foo >> expected.txt
+    echo bar >> expected.txt
+  done
+
+  cmp expected.txt out.txt
+}

--- a/test/50_setup.bats
+++ b/test/50_setup.bats
@@ -1,0 +1,69 @@
+#!/usr/bin/env bats
+
+setup_file() {
+  bats_require_minimum_version 1.7.0
+  load 'common'
+
+  create_simple_repo $BATS_FILE_TMPDIR/testrepo
+}
+
+add_pile_commits() {
+  local n_commits=$1
+  local fn_number=$2
+
+  for (( i=0; i < n_commits; i++, fn_number++ )); do
+    fn="foo${fn_number}.txt"
+    touch $fn
+    git add $fn
+    git commit -m "Add $fn"
+    git pile genpatches -m "Add patch adding $fn"
+  done
+}
+
+setup() {
+  git clone --bare "$BATS_FILE_TMPDIR/testrepo" "$BATS_TEST_TMPDIR/remoterepo"
+
+  git clone "$BATS_TEST_TMPDIR/remoterepo" "$BATS_TEST_TMPDIR/testrepo"
+  pushd "$BATS_TEST_TMPDIR/testrepo"
+  git pile init
+  git checkout -b internal
+
+  add_pile_commits 3 1
+  git push origin -u --all
+}
+
+@test "setup" {
+  git clone "$BATS_TEST_TMPDIR/remoterepo" "$BATS_TEST_TMPDIR/testrepo2"
+  pushd "$BATS_TEST_TMPDIR/testrepo2"
+  git pile setup origin/pile origin/internal
+  [ "$(git -C ../testrepo rev-parse internal)" = "$(git rev-parse internal)" ]
+  [ "$(git -C ../testrepo rev-parse pile)" = "$(git rev-parse pile)" ]
+}
+
+@test "setup-multiple-pile" {
+  git pile setup origin/pile origin/internal
+  pile_head=$(git rev-parse pile)
+  internal_head=$(git rev-parse internal)
+
+  add_pile_commits 1 10
+
+  git push origin pile:pile-next internal:internal-next
+  pile_next_head=$(git rev-parse pile)
+  internal_next_head=$(git rev-parse internal)
+  git pile reset
+
+  git clone "$BATS_TEST_TMPDIR/remoterepo" "$BATS_TEST_TMPDIR/testrepo2"
+  pushd "$BATS_TEST_TMPDIR/testrepo2"
+  # requirement for working with multiple piles
+  git config extensions.worktreeConfig true
+  git pile setup origin/pile origin/internal
+  [ "$(git rev-parse pile)" = "$pile_head" ]
+  [ "$(git rev-parse internal)" = "$internal_head" ]
+
+  git worktree add ../testrepo2-next HEAD
+  pushd ../testrepo2-next
+  git pile setup origin/pile-next origin/internal-next
+  git checkout internal-next
+  [ "$(git rev-parse pile-next)" = "$pile_next_head" ]
+  [ "$(git rev-parse internal-next)" = "$internal_next_head" ]
+}


### PR DESCRIPTION
Make sure our config commands are worktree-aware. This allows having different piles working in the same git repository with checkout in different paths.

User still needs to set `git config extensions.worktreeConfig true` when using multiple piles.

Fix: #7

Signed-off-by: Lucas De Marchi <lucas.demarchi@intel.com>