### PR TITLE
Raise minimum requirement for git

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,6 +124,14 @@ jobs:
           echo "TAP version 13\r" > git.tap
           bats --tap -T test | tee -a git.tap
 
+      - name: Run tests (git v2.20.x)
+        if: always()
+        run: |
+          export PATH=/usr/local/git-v2.20.x/bin:$PATH
+          git --version
+          echo "TAP version 13\r" > git-v2.20.tap
+          bats --tap -T test | tee -a git-v2.20.tap
+
       - name: Run tests (git v2.25.x)
         if: always()
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
       # should be supported in any version of git we support
       - name: Setup git
         run: |
-          git config --global user.name "ci"
+          git config --global user.name "CI Bot"
           git config --global user.email "ci@git-pile.github.io"
           git config --global init.defaultBranch master
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,18 +127,18 @@ jobs:
       - name: Run tests (git v2.25.x)
         if: always()
         run: |
-          export PATH=/usr/local/git-2.25.x:$PATH
+          export PATH=/usr/local/git-v2.25.x/bin:$PATH
           git --version
-          echo "TAP version 13\r" > git-2.25.tap
-          bats --tap -T test | tee -a git-2.25.tap
+          echo "TAP version 13\r" > git-v2.25.tap
+          bats --tap -T test | tee -a git-v2.25.tap
 
       - name: Run tests (git v2.38.x)
         if: always()
         run: |
-          export PATH=/usr/local/git-2.38.x:$PATH
+          export PATH=/usr/local/git-v2.38.x/bin:$PATH
           git --version
-          echo "TAP version 13\r" > git-2.38.tap
-          bats --tap -T test | tee -a git-2.38.tap
+          echo "TAP version 13\r" > git-v2.38.tap
+          bats --tap -T test | tee -a git-v2.38.tap
 
       - name: Generate test summary
         uses: test-summary/action@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,43 +76,25 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v4
-        name: Set up Python
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Install dependencies
+      - name: Workaround directory permissions
         run: |
-          python -m pip install --upgrade pip
-          pip install coverage
+          chown -R $(id -u):$(id -g) .
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
 
-      - name: Export PATH
-        run: echo "$HOME/.local/bin" >> $GITHUB_PATH
-
-      - uses: actions/checkout@v3
-        with:
-          repository: bats-core/bats-core
-          ref: v1.7.0
-          path: test/bats-core
-      - run: test/bats-core/install.sh $HOME/.local
-
-      - name: Use git-pile from checkout
-        run: echo "$PWD" >> $GITHUB_PATH
-
+      # should be supported in any version of git we support
       - name: Setup git
         run: |
           git config --global user.name "ci"
           git config --global user.email "ci@git-pile.github.io"
           git config --global init.defaultBranch master
 
-      # User in the container will be root, but the cloned repo is owned by the
-      # user running github-runner. Git doesn't like that as the repo will then
-      # be unusable by the owner:  we don't care about it since this is only
-      # used for running these tests.
-      #
-      # See https://github.com/actions/runner/issues/2033
-      - name: Workaround directory permissions
-        run: git config --global --add safe.directory $PWD
+      - uses: actions/setup-python@v4
+        name: Set up Python
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install git-pile
+        run: python3 -m pip install --user --no-use-pep517 --editable .[tests]
 
       - name: Enable coverage
         if: ${{ matrix.python-version == '3.10' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,7 +107,6 @@ jobs:
           bats --tap -T test | tee -a git.tap
 
       - name: Run tests (git v2.20.x)
-        if: always()
         run: |
           export PATH=/usr/local/git-v2.20.x/bin:$PATH
           git --version
@@ -115,7 +114,6 @@ jobs:
           bats --tap -T test | tee -a git-v2.20.tap
 
       - name: Run tests (git v2.25.x)
-        if: always()
         run: |
           export PATH=/usr/local/git-v2.25.x/bin:$PATH
           git --version
@@ -123,7 +121,6 @@ jobs:
           bats --tap -T test | tee -a git-v2.25.tap
 
       - name: Run tests (git v2.38.x)
-        if: always()
         run: |
           export PATH=/usr/local/git-v2.38.x/bin:$PATH
           git --version
@@ -132,12 +129,11 @@ jobs:
 
       - name: Generate test summary
         uses: test-summary/action@v2
-        if: always()
         with:
           paths: "*.tap"
 
       # Since coverage is only reported in git-pile itself, there is no need
-      # to report it for all python version - use just one of them
+      # to report it for all python versions - use just one of them
       - name: Coverage results
         if: ${{ matrix.python-version == '3.10' }}
         run: |
@@ -155,3 +151,11 @@ jobs:
         with:
           name: coverage-html
           path: htmlcov/
+
+      - name: Fail on any test failing
+        if: always()
+        run: |
+          if grep -q -e "^not ok" *.tap; then
+              echo "::error Some tests failed"
+              exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Manage a pile of patches on top of a git branch
 ## Requirements
 
  - Python >= 3.7
- - git >= 2.19
+ - git >= 2.20
  - Python modules:
    - argcomplete (optional for shell completion)
    - coverage (optional for tests)

--- a/git_pile/git_pile.py
+++ b/git_pile/git_pile.py
@@ -1903,7 +1903,7 @@ def main(*cmd_args):
     cli.add_command(ResetCmd)
 
     args = parse_args(cli, cmd_args)
-    if args.command not in ("init", "setup"):
+    if args.command not in ("init", "setup", None):
         if not config.normalize(git_root_or_die()):
             fatal("Could not find checkout for result-branch / pile-branch")
 


### PR DESCRIPTION
Now that we have worktree-aware configuration, it's time to raise minimum git requirement. The worktree support was added in git 2.20. Currently we report the minimum version is 2.19 due to the addition of git-range-diff. Raising to 2.20 shouldn't be a problem for distros as they either package something older or more recent than that (confirmed with Ubuntu, Fedora, RHEL/Centos and Debian).

Signed-off-by: Lucas De Marchi <lucas.demarchi@intel.com>