### PR TITLE
ci: Drop python 3.6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.6', '3.7', '3.9', '3.10' ]
+        python-version: [ '3.7', '3.9', '3.10' ]
     steps:
       - uses: actions/checkout@v3
 
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.6', '3.7', '3.9', '3.10' ]
+        python-version: [ '3.7', '3.9', '3.10' ]
     steps:
       - uses: actions/checkout@v3
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Manage a pile of patches on top of a git branch
 
 ## Requirements
 
- - Python >= 3.6
+ - Python >= 3.7
  - git >= 2.19
  - Python modules:
    - argcomplete (optional for shell completion)

--- a/git-pile
+++ b/git-pile
@@ -5,8 +5,8 @@
 import git_pile.git_pile as git_pile
 import sys
 
-if sys.version_info < (3, 6):
-    sys.exit("Sorry, we need at least Python 3.6.x")
+if sys.version_info < (3, 7):
+    sys.exit("Sorry, we need at least Python 3.7.x")
 
 if __name__ == "__main__":
     sys.exit(git_pile.main(*sys.argv[1:]))

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,8 @@ import sys
 HERE = pathlib.Path(__file__).parent
 README = (HERE / "README.md").read_text()
 
-if sys.version_info < (3, 6):
-    sys.exit("Sorry, we need at least Python 3.6.x")
+if sys.version_info < (3, 7):
+    sys.exit("Sorry, we need at least Python 3.7.x")
 
 # installing to user dir or inside virtualenv
 if ("install" in sys.argv and "--user" in sys.argv) or sys.base_prefix != sys.prefix:


### PR DESCRIPTION
Default runner in github-actions is now based on Ubuntu 22.04. There won't be python 3.6 for the new runner since it already reached its EOL: https://peps.python.org/pep-0494/#lifespan. Drop it.

Signed-off-by: Lucas De Marchi <lucas.demarchi@intel.com>