### PR TITLE
Make git-worktree add compatible with git 2.25

### DIFF
--- a/git_pile/git_pile.py
+++ b/git_pile/git_pile.py
@@ -201,7 +201,9 @@ class InitCmd(PileCommand):
 
         # checkout pile branch as a new worktree
         try:
-            git(f"worktree add --checkout {config.dir} {config.pile_branch}", stdout=nul_f, stderr=nul_f)
+            # dir/, with one extra slash to make it compatible with older git versions (e.g. 2.25),
+            # that would fail otherwise
+            git(f"worktree add --checkout {config.dir}/ {config.pile_branch}", stdout=nul_f, stderr=nul_f)
         except:
             config.revert(oldconfig)
             fatal(f"failed to checkout worktree at {config.dir}")
@@ -356,7 +358,9 @@ class SetupCmd(PileCommand):
         if need_worktree:
             # checkout pile branch as a new worktree
             try:
-                git(f"-C {gitroot} worktree add --checkout {args.dir} {local_pile_branch}", stdout=nul_f, stderr=nul_f)
+                # dir/, with one extra slash to make it compatible with older git versions (e.g. 2.25),
+                # that would fail otherwise
+                git(f"-C {gitroot} worktree add --checkout {args.dir}/ {local_pile_branch}", stdout=nul_f, stderr=nul_f)
             except:
                 fatal(f"failed to checkout worktree for '{local_pile_branch}' at {args.dir}")
 

--- a/test/50_setup.bats
+++ b/test/50_setup.bats
@@ -60,6 +60,20 @@ setup() {
   [ "$(git rev-parse pile)" = "$pile_head" ]
   [ "$(git rev-parse internal)" = "$internal_head" ]
 
+  # First, test a pile setup with a trailing slash - some git versions have
+  # issues without a slash, so let's make sure it works with the double slashes
+  # that will result on calls to git-worktree add
+  git worktree add ../testrepo2-next HEAD
+  pushd ../testrepo2-next
+  git pile setup -d patches/ origin/pile-next origin/internal-next
+  git checkout internal-next
+  [ "$(git rev-parse pile-next)" = "$pile_next_head" ]
+  [ "$(git rev-parse internal-next)" = "$internal_next_head" ]
+  popd
+  rm -r ../testrepo2-next
+
+  # remove the new worktrees, try again with no additional dir arg
+  git worktree prune
   git worktree add ../testrepo2-next HEAD
   pushd ../testrepo2-next
   git pile setup origin/pile-next origin/internal-next


### PR DESCRIPTION
git worktree add was failing in Ubuntu 20.04 that has git 2.25.x. For some reason it doesn't like the patches directory not ending in a slash. Although this could be fixed on the user side by forcing the slash in the config, there is no harm in adding one directly in git-pile.

This was the only fix needed for running the complete testsuite in that distro under git 2.25. After the fix:

	28 tests, 0 failures

Signed-off-by: Lucas De Marchi <lucas.demarchi@intel.com>