### PR TITLE
git-pile: Figure out result-dir / pile-dir

### DIFF
--- a/git_pile/config.py
+++ b/git_pile/config.py
@@ -4,10 +4,10 @@ Module providing the ``Config`` class, which is responsible for handling
 git-pile configuration.
 """
 
+from .gitutil import git_worktree_config_extension_enabled
 from .helpers import (
     error,
     git,
-    git_can_fail,
     nul_f,
     run_wrapper,
     warn,
@@ -31,10 +31,6 @@ class Config:
     __attr_doc_genbranch_use_cache = "(bool): Use cached information to avoid recreating commits"
     __attr_doc_genbranch_cache_path = "(path): Path (relative to the .git dir) to the cache file for genbranch"
 
-    @classmethod
-    def per_worktree(cls):
-        return git_can_fail("config --get --bool extensions.worktreeConfig", stderr=nul_f).stdout.strip() == "true"
-
     def __init__(self):
         self.dir = ""
         self.linear_branch = ""
@@ -51,7 +47,7 @@ class Config:
         self.genbranch_cache_path = "pile-genbranch-cache.pickle"
         self.write = None
 
-        if Config.per_worktree():
+        if git_worktree_config_extension_enabled():
             self.write = run_wrapper(["git", "config", "--worktree"], capture=True)
         else:
             self.write = run_wrapper(["git", "config"], capture=True)

--- a/git_pile/genbranch.py
+++ b/git_pile/genbranch.py
@@ -13,7 +13,6 @@ from .config import Config
 from .cli import PileCommand
 from .genbranch_caching import GenbranchCache
 from .gitutil import (
-    git_root_or_die,
     git_split_index,
     git_temporary_worktree,
     git_worktree_get_checkout_path,
@@ -32,7 +31,7 @@ from .helpers import (
 from .pile import Pile
 
 
-def genbranch(root, patchesdir, config, args):
+def genbranch(patchesdir, config, args):
     if not config.check_is_valid():
         return 1
 
@@ -165,9 +164,9 @@ pile patches."""
 
     # work in a separate directory to avoid cluttering whatever the user is doing
     # on the main one
-    with git_temporary_worktree(effective_baseline, root) as d:
+    with git_temporary_worktree(effective_baseline, config.root) as d:
         branch = args.branch if args.branch else config.result_branch
-        path = git_worktree_get_checkout_path(root, branch)
+        path = git_worktree_get_checkout_path(config.root, branch)
 
         if path and not args.force:
             error(f"can't use branch '{branch}' because it is checked out at '{path}'")
@@ -339,10 +338,9 @@ class GenbranchCmd(PileCommand):
     def run(self):
         args = self.args
         config = self.config
-        root = git_root_or_die()
         if args.external_pile:
             patchesdir = args.external_pile
         else:
             patchesdir = op.join(config.root, config.dir)
 
-        return genbranch(root, patchesdir, config, args)
+        return genbranch(patchesdir, config, args)

--- a/git_pile/genbranch.py
+++ b/git_pile/genbranch.py
@@ -291,6 +291,7 @@ class GenbranchCmd(PileCommand):
         self.parser.add_argument(
             "-q", "--quiet", help="Quiet mode - do not print list of patches", action="store_true", default=False
         )
+        self.parser.add_argument("-e", "--external-pile", help="Use external pile dir as input", default=None)
         self.parser.add_argument(
             "-i",
             "--inplace",
@@ -339,5 +340,9 @@ class GenbranchCmd(PileCommand):
         args = self.args
         config = self.config
         root = git_root_or_die()
-        patchesdir = op.join(root, config.dir)
+        if args.external_pile:
+            patchesdir = args.external_pile
+        else:
+            patchesdir = op.join(config.root, config.dir)
+
         return genbranch(root, patchesdir, config, args)

--- a/git_pile/gitutil.py
+++ b/git_pile/gitutil.py
@@ -10,7 +10,6 @@ import subprocess
 import sys
 import tempfile
 
-from .config import Config
 from .helpers import (
     git,
     git_can_fail,
@@ -65,7 +64,7 @@ def git_root_or_die():
 
 @contextlib.contextmanager
 def git_split_index(path="."):
-    if Config.per_worktree():
+    if git_worktree_config_extension_enabled():
         config_cmd = "config --worktree"
     else:
         config_cmd = "config"
@@ -109,6 +108,10 @@ def git_temporary_worktree(commit, dir, prefix="git-pile-worktree"):
             yield d
     finally:
         git(f"worktree remove {d}")
+
+
+def git_worktree_config_extension_enabled():
+    return git_can_fail("config --get --bool extensions.worktreeConfig", stderr=nul_f).stdout.strip() == "true"
 
 
 # Return the path a certain branch is checked out at

--- a/git_pile/gitutil.py
+++ b/git_pile/gitutil.py
@@ -145,3 +145,9 @@ def git_worktree_get_checkout_path(root, branch):
 # the @path. @path defaults to CWD
 def git_worktree_get_git_dir(path="."):
     return git(f"-C {path} rev-parse --git-dir").stdout.strip("\n")
+
+
+def git_worktree_list(root):
+    out = git(f"-C {root} worktree list --porcelain").stdout.splitlines()
+    ret = tuple(op.realpath(s.split(maxsplit=1)[1]) for s in out if s.startswith("worktree"))
+    return ret

--- a/test/00_basic.bats
+++ b/test/00_basic.bats
@@ -2,7 +2,7 @@
 
 setup() {
   bats_require_minimum_version 1.7.0
-  load 'common'
+  load common.bash
 }
 
 @test "version" {

--- a/test/10_init.bats
+++ b/test/10_init.bats
@@ -2,7 +2,7 @@
 
 setup_file() {
   bats_require_minimum_version 1.7.0
-  load 'common'
+  load common.bash
 
   create_simple_repo $BATS_FILE_TMPDIR/testrepo
 }

--- a/test/11_baseline.bats
+++ b/test/11_baseline.bats
@@ -1,0 +1,44 @@
+#!/usr/bin/env bats
+
+setup_file() {
+  bats_require_minimum_version 1.7.0
+  load common.bash
+
+  create_simple_repo $BATS_FILE_TMPDIR/testrepo
+}
+
+setup() {
+  load common.bash
+  git clone "$BATS_FILE_TMPDIR/testrepo" "$BATS_TEST_TMPDIR/testrepo"
+  pushd "$BATS_TEST_TMPDIR/testrepo"
+}
+
+@test "baseline" {
+  head="$(git rev-parse HEAD)"
+
+  git pile init -p pile -r internal
+  git checkout -b internal
+
+  [ "$head" = "$(git rev-parse internal)" ]
+  [ "$head" = "$(git pile baseline)" ]
+  [ "$head" = "$(git -C patches pile baseline)" ]
+}
+
+@test "baseline-multiple-pile" {
+  git pile init -p pile -r internal
+
+  git config extensions.worktreeConfig true
+  git worktree add ../testrepo-old HEAD
+  pushd ../testrepo-old
+
+  git pile init -p pile-old -r internal-old -b HEAD^
+
+  baseline_testrepo=$(git -C "$BATS_TEST_TMPDIR/testrepo" pile baseline)
+  baseline_testrepo_patches=$(git -C "$BATS_TEST_TMPDIR/testrepo/patches" pile baseline)
+  baseline_testrepo_old=$(git -C "$BATS_TEST_TMPDIR/testrepo-old" pile baseline)
+  baseline_testrepo_old_patches=$(git -C "$BATS_TEST_TMPDIR/testrepo-old/patches" pile baseline)
+
+  [ "$baseline_testrepo" = "$baseline_testrepo_patches" ]
+  [ "$baseline_testrepo_old" = "$baseline_testrepo_old_patches" ]
+  [ "$baseline_testrepo" != "$baseline_testrepo_old" ]
+}

--- a/test/20_genpatches.bats
+++ b/test/20_genpatches.bats
@@ -2,7 +2,7 @@
 
 setup_file() {
   bats_require_minimum_version 1.7.0
-  load 'common'
+  load common.bash
 
   create_simple_repo $BATS_FILE_TMPDIR/testrepo
 }

--- a/test/30_genbranch.bats
+++ b/test/30_genbranch.bats
@@ -31,7 +31,7 @@ setup() {
   rev0=$(git rev-parse HEAD)
 
   git pile genpatches -o untracked-output-dir
-  git -c pile.dir=untracked-output-dir pile genbranch -i
+  git pile genbranch -e untracked-output-dir -i
 
   rev1=$(git rev-parse HEAD)
   [ "$(git diff $rev0..$rev1)" = "" ]

--- a/test/30_genbranch.bats
+++ b/test/30_genbranch.bats
@@ -8,6 +8,7 @@ setup_file() {
 }
 
 setup() {
+  load common.bash
   git clone $BATS_FILE_TMPDIR/testrepo $BATS_TEST_TMPDIR/testrepo
   pushd "$BATS_TEST_TMPDIR/testrepo"
   git pile init
@@ -67,4 +68,24 @@ setup() {
   rev0=$(git rev-parse internal)
   rev1=$(git rev-parse test)
   [ "$rev0" = "$rev1" ]
+}
+
+@test "genbranch-call-from-pile-worktree" {
+  add_pile_commits 3 1
+  git pile genbranch -i
+  head=$(git rev-parse HEAD)
+
+  # git-pile doesn't allow this because it would be very confusing
+  # since -i is documented to be "inplace", in the currect worktree
+  run ! git -C patches/ pile genbranch -i
+
+  # without -i it should work as long as it's not checkout anywhere:
+  # it's not ambiguous what the user  is trying to do
+  git -C patches/ pile genbranch -b tmp
+  [ "$head" = "$(git rev-parse tmp)" ]
+
+  pushd patches
+  # doesn't work as the internal branch has a checkout already
+  run ! git pile genbranch
+  popd
 }

--- a/test/30_genbranch.bats
+++ b/test/30_genbranch.bats
@@ -2,7 +2,7 @@
 
 setup_file() {
   bats_require_minimum_version 1.7.0
-  load 'common'
+  load common.bash
 
   create_simple_repo $BATS_FILE_TMPDIR/testrepo
 }

--- a/test/31_genbranch_caching.bats
+++ b/test/31_genbranch_caching.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 setup_file() {
   bats_require_minimum_version 1.7.0
-  load 'common'
+  load common.bash
 
   create_simple_repo "$BATS_FILE_TMPDIR/testrepo"
 }

--- a/test/40_genlinear_branch.bats
+++ b/test/40_genlinear_branch.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 setup_file() {
   bats_require_minimum_version 1.7.0
-  load 'common'
+  load common.bash
 
   create_simple_repo "$BATS_FILE_TMPDIR/testrepo"
 }

--- a/test/40_genlinear_branch.bats
+++ b/test/40_genlinear_branch.bats
@@ -6,21 +6,8 @@ setup_file() {
   create_simple_repo "$BATS_FILE_TMPDIR/testrepo"
 }
 
-add_pile_commits() {
-  local n_commits=$1
-  local fn_number=$2
-
-  for i in $(seq 1 $n_commits); do
-    fn="foo${fn_number}.txt"
-    touch $fn
-    git add $fn
-    git commit -m "Add $fn"
-    git pile genpatches -m "Add patch adding $fn"
-    let fn_number+=1
-  done
-}
-
 setup() {
+  load common.bash
   git clone --bare "$BATS_FILE_TMPDIR/testrepo" "$BATS_TEST_TMPDIR/remoterepo"
 
   git clone "$BATS_TEST_TMPDIR/remoterepo" "$BATS_TEST_TMPDIR/testrepo"

--- a/test/50_setup.bats
+++ b/test/50_setup.bats
@@ -7,20 +7,8 @@ setup_file() {
   create_simple_repo $BATS_FILE_TMPDIR/testrepo
 }
 
-add_pile_commits() {
-  local n_commits=$1
-  local fn_number=$2
-
-  for (( i=0; i < n_commits; i++, fn_number++ )); do
-    fn="foo${fn_number}.txt"
-    touch $fn
-    git add $fn
-    git commit -m "Add $fn"
-    git pile genpatches -m "Add patch adding $fn"
-  done
-}
-
 setup() {
+  load common.bash
   git clone --bare "$BATS_FILE_TMPDIR/testrepo" "$BATS_TEST_TMPDIR/remoterepo"
 
   git clone "$BATS_TEST_TMPDIR/remoterepo" "$BATS_TEST_TMPDIR/testrepo"
@@ -30,13 +18,6 @@ setup() {
 
   add_pile_commits 3 1
   git push origin -u --all
-}
-
-# continuation to setup() above, for tests that need it
-setup_second_pile() {
-  local suffix=$1
-  add_pile_commits 1 10
-  git push origin pile:pile${suffix} internal:internal${suffix}
 }
 
 @test "setup" {

--- a/test/50_setup.bats
+++ b/test/50_setup.bats
@@ -2,7 +2,7 @@
 
 setup_file() {
   bats_require_minimum_version 1.7.0
-  load 'common'
+  load common.bash
 
   create_simple_repo $BATS_FILE_TMPDIR/testrepo
 }

--- a/test/60_format_patch_and_am.bats
+++ b/test/60_format_patch_and_am.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 setup_file() {
   bats_require_minimum_version 1.7.0
-  load 'common'
+  load common.bash
 
   create_simple_repo "$BATS_FILE_TMPDIR/testrepo"
 }

--- a/test/common.bash
+++ b/test/common.bash
@@ -28,6 +28,6 @@ create_simple_repo() {
   popd
 }
 
-if [[ -n $COVERAGE ]]; then
+if [[ -n $COVERAGE ]] && ! [[ "$PATH" =~ (^|:)"$BATS_TEST_DIRNAME/coverage-shim"(:|$) ]]; then
     export PATH="$BATS_TEST_DIRNAME/coverage-shim:$PATH"
 fi

--- a/test/common.bash
+++ b/test/common.bash
@@ -28,6 +28,27 @@ create_simple_repo() {
   popd
 }
 
+add_pile_commits() {
+  local n_commits=$1
+  local fn_number=$2
+
+  for (( i=0; i < n_commits; i++, fn_number++ )); do
+    fn="foo${fn_number}.txt"
+    touch $fn
+    git add $fn
+    git commit -m "Add $fn"
+    git pile genpatches -m "Add patch adding $fn"
+  done
+}
+
+# continuation to a setup() phase, for tests that need it assumptions: there
+# are already a pile and an internal branches created
+setup_second_pile() {
+  local suffix=$1
+  add_pile_commits 1 10
+  git push origin pile:pile${suffix} internal:internal${suffix}
+}
+
 if [[ -n $COVERAGE ]] && ! [[ "$PATH" =~ (^|:)"$BATS_TEST_DIRNAME/coverage-shim"(:|$) ]]; then
     export PATH="$BATS_TEST_DIRNAME/coverage-shim:$PATH"
 fi


### PR DESCRIPTION
pile.dir is always relative to a result-dir: use that information so git-pile tries to fallback in case commands are called from within the pile checkout.

Fix: #104
Signed-off-by: Lucas De Marchi <lucas.demarchi@intel.com>