### PR TITLE
github: use container for testing different git versions

### DIFF
--- a/.github/Dockerfile.ubuntu-22.04
+++ b/.github/Dockerfile.ubuntu-22.04
@@ -1,0 +1,17 @@
+FROM ubuntu:22.04
+RUN echo 'APT::Install-Suggests "0";' >> /etc/apt/apt.conf.d/00-docker
+RUN echo 'APT::Install-Recommends "0";' >> /etc/apt/apt.conf.d/00-docker
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
+  DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        git python3 python3-pip \
+        build-essential libssl-dev zlib1g-dev libcurl4-openssl-dev libexpat-dev gettext coreutils && \
+  pip install flake8
+ENV GIT_VERSIONS="v2.38.1 v2.25.5"
+RUN git clone https://github.com/git/git && cd git && \
+  for v in $GIT_VERSIONS; do \
+    git checkout $v && \
+    vv=${v%.*}.x && \
+    NO_TCLTK=1 make prefix=/usr/local/git-$vv -j$(nproc) && \
+    NO_TCLTK=1 make prefix=/usr/local/git-$vv install; \
+  done && cd - && rm -rf git
+LABEL org.opencontainers.image.source=https://github.com/git-pile/git-pile

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ jobs:
     strategy:
       matrix:
         python-version: [ '3.7', '3.9', '3.10' ]
+
     steps:
       - uses: actions/checkout@v3
 
@@ -65,6 +66,11 @@ jobs:
 
   integration-tests:
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/git-pile/builder:test
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.github_token }}
     strategy:
       matrix:
         python-version: [ '3.7', '3.9', '3.10' ]
@@ -76,10 +82,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install --yes bats
+      - name: Export PATH
+        run: echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - uses: actions/checkout@v3
         with:
@@ -97,5 +101,19 @@ jobs:
           git config --global user.email "ci@git-pile.github.io"
           git config --global init.defaultBranch master
 
-      - name: Run tests
-        run: bats --print-output-on-failure --show-output-of-passing-tests --tap -T test
+      - name: Run tests (git from distro)
+        run: |
+          git --version
+          bats --print-output-on-failure --show-output-of-passing-tests --tap -T test
+
+      - name: Run tests (git v2.25.x)
+        run: |
+          export PATH=/usr/local/git-2.25.x:$PATH
+          git --version
+          bats --print-output-on-failure --show-output-of-passing-tests --tap -T test
+
+      - name: Run tests (git v2.38.x)
+        run: |
+          export PATH=/usr/local/git-2.38.x:$PATH
+          git --version
+          bats --print-output-on-failure --show-output-of-passing-tests --tap -T test

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,44 @@
+name: builder-container
+
+on:
+  push:
+    branches: [ ci, master ]
+    path:
+      - '.github/workflows/container.yml'
+      - '.github/Dockerfile.ubuntu-22.04'
+  workflow_dispatch:
+    inputs:
+      git-ref:
+        description: Git Ref (Optional)
+        required: false
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: builder
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build image
+        id: build
+        run: |
+          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+          [ "$VERSION" == "master" ] && TAG=latest
+          [ "$VERSION" == "ci" ] && TAG=test
+          docker build .github/ --file .github/Dockerfile.ubuntu-22.04 --tag $IMAGE_ID:$TAG --label "runnumber=${GITHUB_RUN_ID}"
+          echo "::set-output name=image::$IMAGE_ID:$TAG"
+
+      - name: Log in to the Container registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
+
+      - name: Push image
+        run: docker push ${{ steps.build.outputs.image }}


### PR DESCRIPTION
As detailed in https://github.com/git-pile/git-pile/pull/103#issuecomment-1336298909, this is the compromise to use our own builds of git without having to build them on every PR. 

Fix: #92 