### PR TITLE
genbranch: Add option --pile-rev

### DIFF
--- a/test/30_genbranch.bats
+++ b/test/30_genbranch.bats
@@ -89,3 +89,15 @@ setup() {
   run ! git pile genbranch
   popd
 }
+
+@test "genbranch-rev" {
+  add_pile_commits 3 1
+  git pile genbranch -i
+  head=$(git rev-parse HEAD)
+
+  add_pile_commits 1 4
+  git pile genbranch -i
+
+  git pile genbranch -i --pile-rev pile~1
+  [ "$head" = "$(git rev-parse HEAD)" ]
+}


### PR DESCRIPTION
Useful to generate the result branch from a previous pile revision without touching the pile checkout. E.g.:

  git pile genbranch --rev pile~3