### PR TITLE
genbranch: Allow running without a setup in place

### DIFF
--- a/git_pile/cli.py
+++ b/git_pile/cli.py
@@ -57,6 +57,10 @@ Notes regarding ``PileCommand`` subclasses:
   - The class attribute ``supports_no_config`` should be set True for commands
     that are supposed to handle calls with option ``--no-config`` passed.
 
+  - The class attribute ``skip_config_normalize`` should be set True for commands
+    that should not have the config object being automatically normalized (i.e.
+    have ``Config.normalized()`` called).
+
   - There are two main methods expected to be implemented by subclasses:
 
     1. ``init()``: this is where initialization (like adding arguments) is done.
@@ -103,6 +107,9 @@ class PileCommand:
 
         if not hasattr(cls, "supports_no_config"):
             cls.supports_no_config = False
+
+        if not hasattr(cls, "skip_config_normalize"):
+            cls.skip_config_normalize = False
 
     @classmethod
     def __default_cmd_name(cls):
@@ -151,7 +158,7 @@ class PileCLI:
 
             self.config = configmod.Config(skip_load=args.no_config)
 
-            if args.command not in ("init", "setup") and not args.no_config:
+            if not cmd.skip_config_normalize and not args.no_config:
                 if not self.config.normalize(self.config.root):
                     helpers.fatal("Could not find checkout for result-branch / pile-branch")
 

--- a/git_pile/genbranch.py
+++ b/git_pile/genbranch.py
@@ -38,7 +38,12 @@ def genbranch(config, args):
 
 
 def genbranch_with_exit_stack(config, args, exit_stack):
-    if not config.check_is_valid():
+    if args.no_config:
+        if not (args.external_pile or args.pile_rev):
+            fatal("--external-pile or --pile-rev is required when using --no-config")
+        if not (args.inplace or args.branch):
+            fatal("--inplace or --branch is required when using --no-config")
+    elif not config.check_is_valid():
         return 1
 
     if args.external_pile and args.pile_rev:
@@ -297,8 +302,21 @@ class GenbranchCmd(PileCommand):
     Generate RESULT_BRANCH by applying patches from PILE_BRANCH on top of BASELINE
     """
 
-    parser_epilog = Config.help("genbranch")
+    parser_epilog = (
+        Config.help("genbranch")
+        + """
+
+Running without a setup in place:
+  The genbranch command is usually run with a repository already configured for
+  git-pile, however it is also possible to use --no-config to generate the
+  result branch without a setup in place (e.g. "git pile --no-config genbranch
+  -i -e path/to/patches").
+"""
+    )
+
     parser_formatter_class = argparse.RawTextHelpFormatter
+
+    supports_no_config = True
 
     def init(self):
         self.parser.add_argument(

--- a/git_pile/git_pile.py
+++ b/git_pile/git_pile.py
@@ -1888,9 +1888,7 @@ def parse_args(cli, cmd_args):
 def main(*cmd_args):
     log_enable_color(sys.stdout.isatty(), sys.stderr.isatty())
 
-    config = Config()
-
-    cli = PileCLI(config)
+    cli = PileCLI()
     cli.add_command(InitCmd)
     cli.add_command(SetupCmd)
     cli.add_command(GenpatchesCmd)
@@ -1903,10 +1901,6 @@ def main(*cmd_args):
     cli.add_command(ResetCmd)
 
     args = parse_args(cli, cmd_args)
-    if args.command not in ("init", "setup", None):
-        if not config.normalize(git_root_or_die()):
-            fatal("Could not find checkout for result-branch / pile-branch")
-
     try:
         return cli.run(args)
     except KeyboardInterrupt:

--- a/git_pile/git_pile.py
+++ b/git_pile/git_pile.py
@@ -128,6 +128,8 @@ class InitCmd(PileCommand):
     Initialize configuration of an empty pile in this repository
     """
 
+    skip_config_normalize = True
+
     def init(self):
         self.parser.add_argument(
             "-d", "--dir", help="Directory in which to place patches (default: %(default)s)", metavar="DIR", default="patches"
@@ -220,6 +222,8 @@ class SetupCmd(PileCommand):
     """
     Setup/copy configuration from a remote or already created branches
     """
+
+    skip_config_normalize = True
 
     def init(self):
         self.parser.add_argument(


### PR DESCRIPTION
This is useful for generating the result branch on respositories containing the baseline but not configured for git-pile.

See https://github.com/git-pile/git-pile/pull/111#issuecomment-1473997609 for context.