### PR TITLE
format-patch: Fix sequence of range check calls

### DIFF
--- a/git_pile/git_pile.py
+++ b/git_pile/git_pile.py
@@ -1160,8 +1160,8 @@ def _parse_format_refs(refs, current_baseline):
             oldref = None
             try:
                 oldbaseline = git(f"rev-parse {r1[0]}", stderr=nul_f).stdout.strip()
-                newbaseline = git(f"rev-parse {r2[0]}", stderr=nul_f).stdout.strip()
                 oldref = git(f"rev-parse {r1[1]}", stderr=nul_f).stdout.strip()
+                newbaseline = git(f"rev-parse {r2[0]}", stderr=nul_f).stdout.strip()
                 newref = git(f"rev-parse {r2[1]}", stderr=nul_f).stdout.strip()
             except subprocess.CalledProcessError:
                 if not oldbaseline or not oldref:


### PR DESCRIPTION
Do the calls for the old range before the ones for the new range, otherwise the wrong error message is shown when the new baseline is an invalid revision (because oldref would still be None).

(I just happened to bump into this scenario and decided to send a quick fix 🙂 )