### PR TITLE
genbranch: Use patchesdir for repository path in cache logic

### DIFF
--- a/git_pile/genbranch.py
+++ b/git_pile/genbranch.py
@@ -121,7 +121,7 @@ def genbranch_with_exit_stack(config, args, exit_stack):
                 pass
 
         if cache_pile_rev:
-            pile_for_cache = Pile(rev=cache_pile_rev, baseline=args.baseline)
+            pile_for_cache = Pile(rev=cache_pile_rev, rev_repo_path=patchesdir, baseline=args.baseline)
 
         effective_baseline, patchlist_offset = cache.search_best_base(pile_for_cache)
         if patchlist_offset:


### PR DESCRIPTION
We use caching for speeding up genbranch execution. As a further optimization, we try to use a git tree for the pile object to avoid recalculating hashes for patch files.

One issue that recently happened was that a patchesdir was passed that belonged to another repository, and that confused genbranch, because it assumed the patchesdir lived in the same repository as the current working directory's.

To fix that, let's modify Pile to accept a rev_repo_path argument to allow it to use a different path as base for an instance created with Pile(rev=...); and have genbranch always passing patchesdir to that argument when doing the optimization aforementioned.