### PR TITLE
pile: Pass path components to reader instance

### DIFF
--- a/git_pile/pile.py
+++ b/git_pile/pile.py
@@ -168,7 +168,7 @@ class PilePatch:
         self.__reader = reader
 
     def sha1(self):
-        return self.__reader.sha1(self.name)
+        return self.__reader.sha1(*pathlib.Path(self.name).parts)
 
 
 class PileError(Exception):


### PR DESCRIPTION
Methods of _FileReader expect path components in positional arguments and we are passing the full path string to sha1(). Fix that by extracting the components with pathlib.

Fixes: a7e0f7f25a87 ("pile: Add method Pile.series()")